### PR TITLE
feat(search): add grammar-aware language filtering and improve identi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,48 +81,59 @@ This project was originally built for personal use — a solo experiment in loca
 
 ## Quick Start
 
-```bash
-# 1. Clone this repository and start infrastructure:
-git clone https://github.com/VioletCranberry/coco-s.git && cd coco-s
-# Docker volumes are bind-mounted to ./docker_data/ inside the repository,
-# so infrastructure must be started from the cloned repo directory.
-docker compose up -d
-# 2. Verify services are ready.
-uvx cocosearch config check
-# 3. Index your project (or use WEB dashboard).
-uvx cocosearch index .
-# 4. Register with your AI assistant (pick one):
-```
+- **Services**:
 
-**Option A — Plugin (recommended):**
+  ```bash
+  # 1. Clone this repository and start infrastructure:
+  git clone https://github.com/VioletCranberry/coco-s.git && cd coco-s
+  # Docker volumes are bind-mounted to ./docker_data/ inside the repository,
+  # so infrastructure must be started from the cloned repo directory.
+  docker compose up -d
+  # 2. Verify services are ready.
+  uvx cocosearch config check
+  ```
 
-```bash
-claude plugin marketplace add VioletCranberry/coco-s
-claude plugin install cocosearch@cocosearch
-# All 7 skills + MCP server configured automatically
-```
+- **Indexing your projects**:
 
-<p align="center">
-  <img src="./docs/plugin-examples.png" alt="CocoSearch plugin skills in Claude Code" width="720">
-</p>
+  ```bash
+  # 3.1 Use WEB Dashboard:
+  uvx cocosearch dashboard
+  # 3.2 Use CLI:
+  uvx cocosearch index .
+  # 3.3 Use AI and MCP - see below.
+  ```
 
-**Option B — Manual MCP registration:**
+- **Register with your AI assistant (pick one)**:
 
-```bash
-claude mcp add --scope user cocosearch -- \
-  uvx cocosearch mcp --project-from-cwd
-```
+  **Option A — Plugin (recommended):**
 
-> **Note:** The MCP server automatically opens a web dashboard in your browser on a random port. Set `COCOSEARCH_DASHBOARD_PORT=8080` to pin it to a fixed port, or `COCOSEARCH_NO_DASHBOARD=1` to disable it.
+  ```bash
+  claude plugin marketplace add VioletCranberry/coco-s
+  claude plugin install cocosearch@cocosearch
+  # All 7 skills + MCP server configured automatically
+  ```
 
-Install skills manually (for development):
+  <p align="center">
+    <img src="./docs/plugin-examples.png" alt="CocoSearch plugin skills in Claude Code" width="720">
+  </p>
 
-```bash
-mkdir -p .claude/skills
-for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway; do
-    ln -sfn "../../skills/$skill" ".claude/skills/$skill"
-done
-```
+  **Option B — Manual MCP registration:**
+
+  ```bash
+  claude mcp add --scope user cocosearch -- \
+    uvx cocosearch mcp --project-from-cwd
+  ```
+
+  > **Note:** The MCP server automatically opens a web dashboard in your browser on a random port. Set `COCOSEARCH_DASHBOARD_PORT=8080` to pin it to a fixed port, or `COCOSEARCH_NO_DASHBOARD=1` to disable it.
+
+  Install skills manually (for development):
+
+  ```bash
+  mkdir -p .claude/skills
+  for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway; do
+      ln -sfn "../../skills/$skill" ".claude/skills/$skill"
+  done
+  ```
 
 ## Features
 

--- a/src/cocosearch/dashboard/web/static/index.html
+++ b/src/cocosearch/dashboard/web/static/index.html
@@ -1094,12 +1094,13 @@
                 <div class="search-advanced-content">
                     <label>Min score: <input type="range" id="searchMinScore" min="0" max="1" step="0.05" value="0.3"> <span id="minScoreValue">0.3</span></label>
                     <label>Limit: <input type="number" id="searchLimit" min="1" max="50" value="10"></label>
-                    <label>Hybrid search:
+                    <label title="Combines semantic (vector) and keyword (tsvector) search via RRF fusion. Auto enables it only for code identifiers (camelCase, snake_case, PascalCase).">Hybrid search:
                         <select id="searchHybrid">
                             <option value="auto" selected>Auto</option>
                             <option value="on">On</option>
                             <option value="off">Off</option>
                         </select>
+                        <span style="font-size: 11px; color: var(--text-secondary); font-style: italic;">Auto = on for code identifiers only</span>
                     </label>
                 </div>
             </details>
@@ -1813,7 +1814,8 @@
                             select.value = String(selectedIndex);
                         }
                     } else {
-                        // Project not indexed — show the banner
+                        // Project not indexed — show the banner, hide loading
+                        document.getElementById('loadingMessage').style.display = 'none';
                         const banner = document.getElementById('notIndexedBanner');
                         document.getElementById('notIndexedPath').textContent = projectContext.project_path;
                         banner.style.display = 'block';
@@ -2003,9 +2005,12 @@
                     btn.disabled = false;
                     return;
                 }
-                // Hide the not-indexed banner
+                // Hide the not-indexed banner and loading message
                 document.getElementById('notIndexedBanner').style.display = 'none';
+                document.getElementById('loadingMessage').style.display = 'none';
                 showStatusBanner(data.message, 'info');
+                // Show dashboard immediately with indexing-in-progress state
+                document.getElementById('dashboardContent').style.display = 'block';
                 setButtonsDisabled(true);
                 // Immediately reflect indexing status in the Status card
                 const statusEl = document.getElementById('indexStatus');
@@ -2041,6 +2046,9 @@
                                 `<option value="${i}">${idx.name}</option>`
                             ).join('');
                             select.value = String(matchIdx);
+                            // Ensure dashboard is visible (may already be from indexCurrentProject)
+                            document.getElementById('loadingMessage').style.display = 'none';
+                            document.getElementById('dashboardContent').style.display = 'block';
                             updateDashboard(allIndexes[matchIdx]);
 
                             const status = allIndexes[matchIdx].status || 'indexed';
@@ -2049,9 +2057,6 @@
                                 setButtonsDisabled(false);
                                 showStatusBanner('Indexing complete', 'success');
                                 setTimeout(hideStatusBanner, 5000);
-                                // Show dashboard content now that we have data
-                                document.getElementById('loadingMessage').style.display = 'none';
-                                document.getElementById('dashboardContent').style.display = 'block';
                             }
                             return;
                         }

--- a/src/cocosearch/search/hybrid.py
+++ b/src/cocosearch/search/hybrid.py
@@ -522,20 +522,21 @@ def hybrid_search(
             where_parts.append(symbol_where)
             where_params.extend(symbol_params)
 
-    # Add language filter conditions (handler language_id + filename-based)
+    # Add language filter conditions (handler/grammar language_id + filename-based)
     if language_filter:
         from cocosearch.search.query import (
             LANGUAGE_EXTENSIONS,
-            HANDLER_LANGUAGES,
+            _get_language_id_map,
             get_extension_patterns,
         )
 
+        lang_id_map = _get_language_id_map()
         languages = [lang.strip() for lang in language_filter.split(",")]
         lang_conditions = []
         for lang in languages:
-            if lang in HANDLER_LANGUAGES:
+            if lang in lang_id_map:
                 lang_conditions.append("language_id = %s")
-                where_params.append(HANDLER_LANGUAGES[lang])
+                where_params.append(lang_id_map[lang])
             elif lang in LANGUAGE_EXTENSIONS:
                 extensions = get_extension_patterns(lang)
                 ext_parts = ["filename LIKE %s" for _ in extensions]

--- a/tests/unit/test_query_analyzer.py
+++ b/tests/unit/test_query_analyzer.py
@@ -68,6 +68,44 @@ class TestHasIdentifierPattern:
         """Test whitespace-only query."""
         assert has_identifier_pattern("   ") is False
 
+    def test_no_match_for_proper_nouns_short(self):
+        """Test that short proper nouns with mixed case don't trigger detection."""
+        assert has_identifier_pattern("How do I publish to PyPi?") is False
+        assert has_identifier_pattern("macOS compatibility") is False
+        assert has_identifier_pattern("How does GitHub Actions work?") is False
+        assert has_identifier_pattern("setup FastAPI server") is False
+
+    def test_still_matches_long_pascal_case(self):
+        """Test that long PascalCase words (8+ chars) still match as identifiers."""
+        assert has_identifier_pattern("JavaScript ecosystem") is True
+        assert has_identifier_pattern("PostgreSQL connection") is True
+        assert has_identifier_pattern("how to use CocoIndex") is True
+
+    def test_camelcase_requires_lowercase_start(self):
+        """Test that camelCase detection requires word to start lowercase."""
+        assert has_identifier_pattern("getUserById") is True
+        assert has_identifier_pattern("isValid") is True
+        assert has_identifier_pattern("httpGet") is True
+        # These start uppercase — not camelCase
+        assert has_identifier_pattern("PyPi") is False
+        assert has_identifier_pattern("macOS") is False
+
+    def test_camelcase_requires_min_length(self):
+        """Test that camelCase detection requires 6+ character words."""
+        assert has_identifier_pattern("myVar") is False  # 5 chars
+        assert has_identifier_pattern("isOk") is False  # 4 chars
+        assert has_identifier_pattern("myFunc") is True  # 6 chars
+        assert has_identifier_pattern("isValid") is True  # 7 chars
+
+    def test_pascal_case_requires_min_length(self):
+        """Test that PascalCase detection requires 8+ character words."""
+        assert has_identifier_pattern("PyPi") is False  # 4 chars
+        assert has_identifier_pattern("GitHub") is False  # 6 chars
+        assert has_identifier_pattern("FastAPI") is False  # 7 chars
+        assert has_identifier_pattern("HttpClient") is True  # 10 chars
+        assert has_identifier_pattern("UserRepository") is True  # 14 chars
+        assert has_identifier_pattern("MyClassName") is True  # 11 chars
+
 
 class TestNormalizeQueryForKeyword:
     """Tests for normalize_query_for_keyword function."""


### PR DESCRIPTION
1. search/query.py + hybrid.py — Grammar-aware language filtering: grammar handler names
  (github-actions, docker-compose, etc.) are now valid --language filter values via lazy-loaded
   autodiscovery
2. search/query_analyzer.py + tests — Reduced false positives in code identifier detection:
per-word analysis with minimum length thresholds (camelCase 6+ chars, PascalCase 8+ chars) to
 avoid triggering on proper nouns like PyPi, GitHub, FastAPI
3. dashboard index.html — UX fixes: show dashboard immediately during indexing, add hybrid
search tooltip
4. README.md — Restructure Quick Start into clearer sections