### PR TITLE
fix: remove misleading max_turns from AI chat stats display

### DIFF
--- a/src/cocosearch/chat/session.py
+++ b/src/cocosearch/chat/session.py
@@ -34,6 +34,7 @@ except ImportError:
     _SDK_AVAILABLE = False
 
 _MAX_SESSIONS = 10
+_MAX_TURNS = 20
 _SESSION_TIMEOUT_SECS = 30 * 60  # 30 minutes
 _CLEANUP_INTERVAL_SECS = 5 * 60  # 5 minutes
 
@@ -177,7 +178,7 @@ class ChatSession:
                 "Always cite file paths and line numbers in your answers."
             ),
             include_partial_messages=True,
-            max_turns=20,
+            max_turns=_MAX_TURNS,
         )
         self._client = ClaudeSDKClient(options)
         await self._client.connect()
@@ -254,11 +255,9 @@ class ChatSession:
                                 }
                             )
                 elif isinstance(message, ResultMessage):
-                    # Emit session stats from the completed turn
                     stats: dict[str, Any] = {
                         "type": "stats",
                         "num_turns": message.num_turns,
-                        "max_turns": 20,
                         "cost_usd": message.total_cost_usd,
                         "duration_ms": message.duration_ms,
                     }

--- a/src/cocosearch/dashboard/web/static/index.html
+++ b/src/cocosearch/dashboard/web/static/index.html
@@ -2957,8 +2957,8 @@
             const bar = document.getElementById('chatStatsBar');
             const parts = [];
 
-            if (stats.num_turns != null && stats.max_turns) {
-                parts.push('Turns: ' + stats.num_turns + '/' + stats.max_turns);
+            if (stats.num_turns != null) {
+                parts.push('Turns: ' + stats.num_turns);
             }
 
             if (stats.usage) {


### PR DESCRIPTION
The SDK's num_turns can exceed the hardcoded max_turns=20 shown in the dashboard, producing confusing stats like "30/20". The max_turns limit is an internal SDK concern, not meaningful to users.