### PR TITLE
fix: prevent stale favicon reverting to green on subsequent API calls

### DIFF
--- a/src/cocosearch/dashboard/server.py
+++ b/src/cocosearch/dashboard/server.py
@@ -750,13 +750,16 @@ class DashboardHandler(BaseHTTPRequestHandler):
                     active = _active_indexing.get(idx["name"])
                 if active is not None and active.is_alive():
                     result["status"] = "indexing"
-                    # Correct DB so CLI reads consistent status (also refreshes
-                    # updated_at to prevent auto_recover_stale_indexing misfiring)
+                    # Correct DB so CLI reads consistent status. Use
+                    # update_timestamp=False to preserve the original
+                    # updated_at — otherwise staleness checks reset.
                     if stats.status != "indexing":
                         try:
                             from cocosearch.management import set_index_status
 
-                            set_index_status(idx["name"], "indexing")
+                            set_index_status(
+                                idx["name"], "indexing", update_timestamp=False
+                            )
                         except Exception:
                             pass
                 if include_failures:
@@ -789,12 +792,14 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 active = _active_indexing.get(index_name)
             if active is not None and active.is_alive():
                 result["status"] = "indexing"
-                # Correct DB so CLI reads consistent status
+                # Correct DB so CLI reads consistent status. Use
+                # update_timestamp=False to preserve the original
+                # updated_at — otherwise staleness checks reset.
                 if stats.status != "indexing":
                     try:
                         from cocosearch.management import set_index_status
 
-                        set_index_status(index_name, "indexing")
+                        set_index_status(index_name, "indexing", update_timestamp=False)
                     except Exception:
                         pass
             if include_failures:

--- a/src/cocosearch/dashboard/web/static/index.html
+++ b/src/cocosearch/dashboard/web/static/index.html
@@ -1668,6 +1668,8 @@
             const statusEl = document.getElementById('indexStatus');
             const statusLabelEl = document.getElementById('statusLabel');
             const status = stats.status || 'indexed';
+            const isStaleState = status === 'indexed' &&
+                (stats.is_stale || (stats.commits_behind !== null && stats.commits_behind > 0));
             if (status === 'indexing') {
                 statusEl.textContent = 'Indexing...';
                 statusEl.style.color = 'var(--accent-orange)';
@@ -1676,16 +1678,16 @@
                 statusEl.textContent = 'Error';
                 statusEl.style.color = 'var(--accent-red, #ef4444)';
                 statusLabelEl.textContent = 'Indexing failed';
+            } else if (isStaleState) {
+                statusEl.textContent = 'Stale';
+                statusEl.style.color = '#FFC107';
+                statusLabelEl.textContent = stats.commits_behind > 0 ? 'Behind HEAD' : 'Outdated index';
             } else {
                 statusEl.textContent = 'Indexed';
                 statusEl.style.color = 'var(--accent-green)';
                 statusLabelEl.textContent = 'Ready to search';
             }
-            let tabStatus = status;
-            if (status === 'indexed' && (stats.is_stale || (stats.commits_behind !== null && stats.commits_behind > 0))) {
-                tabStatus = 'stale';
-            }
-            updateTabStatus(tabStatus);
+            updateTabStatus(isStaleState ? 'stale' : status);
 
             // Parse Health
             const parseHealthEl = document.getElementById('parseHealth');

--- a/src/cocosearch/mcp/server.py
+++ b/src/cocosearch/mcp/server.py
@@ -97,7 +97,7 @@ def _apply_thread_liveness_status(
         result["status"] = "indexing"
         if db_status != "indexing":
             try:
-                set_index_status(index_name, "indexing")
+                set_index_status(index_name, "indexing", update_timestamp=False)
             except Exception:
                 pass
 


### PR DESCRIPTION
Housekeeping paths (auto_recover_stale_indexing, thread-liveness corrections) were resetting updated_at via set_index_status(), causing check_staleness() to see a fresh timestamp and return is_stale=False on reload. Add update_timestamp parameter to set_index_status() and pass False from all housekeeping callers. Also show "Stale" in amber on the Status card instead of always showing green "Indexed".