### PR TITLE
fix: prevent double browser open and unify dashboard stats

### DIFF
--- a/src/cocosearch/cli.py
+++ b/src/cocosearch/cli.py
@@ -1695,6 +1695,9 @@ def dashboard_command(args: argparse.Namespace) -> int:
         timer.daemon = True
         timer.start()
 
+    # Suppress run_server()'s own browser open — we already opened above
+    os.environ["COCOSEARCH_NO_DASHBOARD"] = "1"
+
     # Use MCP server with SSE transport (provides HTTP routes)
     try:
         run_server(transport="sse", host=args.host, port=port)


### PR DESCRIPTION
Two bugs fixed:

1. Running `cocosearch dashboard` opened two browser tabs because dashboard_command() opened one and then run_server(transport="sse") opened another. Now sets COCOSEARCH_NO_DASHBOARD=1 before calling run_server() to suppress its auto-open.

2. The MCP stdio dashboard didn't report stale indexes correctly because DashboardHandler had its own diverged stats implementation and a separate _active_indexing thread registry. Extracted shared build_all_stats() and build_single_stats() helpers in mcp/server.py and made DashboardHandler delegate to them. Also added grammar_failures to the MCP stats API (was missing) and replaced raw cocoindex.init() calls with the thread-safe _ensure_cocoindex_init().