### PR TITLE
feat: add cocosearch-add-grammar skill and update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,8 @@ When this plugin is active, you have access to MCP tools and workflow skills for
 - `/cocosearch:cocosearch-refactoring` — Impact analysis and safe refactoring
 - `/cocosearch:cocosearch-new-feature` — Pattern-matching feature development
 - `/cocosearch:cocosearch-subway` — Codebase visualization as subway map
-- `/cocosearch:cocosearch-add-language` — Add language support (handlers, symbols, grammars, context expansion)
+- `/cocosearch:cocosearch-add-language` — Add language support (handlers, symbols, context expansion)
+- `/cocosearch:cocosearch-add-grammar` — Add grammar handler (domain-specific formats within a base language)
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Available as a WEB dashboard, CLI, MCP server, or interactive REPL. Incremental 
 - [🏆 Where MCP Wins](#where-mcp-wins)
 - [📚 Useful Documentation](#useful-documentation)
 - [🧩 Components](#components)
+  - [Available MCP Tools](#available-mcp-tools)
+  - [Available Skills](#available-skills)
 - [⚙️ How Search Works](#how-search-works)
 - [🌐 Supported Languages](#supported-languages)
 - [📝 Supported Grammars](#supported-grammars)
@@ -118,82 +120,59 @@ This project was originally built for personal use — a solo experiment in loca
 
 - **Services**:
 
-  ```bash
-  # 1. Clone this repository and start infrastructure:
-  git clone https://github.com/VioletCranberry/coco-s.git && cd coco-s
-  # Docker volumes are bind-mounted to ./docker_data/ inside the repository,
-  # so infrastructure must be started from the cloned repo directory.
-  docker compose up -d
-  # 2. Verify services are ready.
-  uvx cocosearch config check
-  ```
+```bash
+# 1. Clone this repository and start infrastructure:
+git clone https://github.com/VioletCranberry/coco-s.git && cd coco-s
+# Docker volumes are bind-mounted to ./docker_data/ inside the repository,
+# so infrastructure must be started from the cloned repo directory.
+docker compose up -d
+# 2. Verify services are ready.
+uvx cocosearch config check
+```
 
 - **Indexing your projects**:
 
-  ```bash
-  # 3.1 Use WEB Dashboard:
-  uvx cocosearch dashboard
-  # 3.2 Use CLI:
-  uvx cocosearch index .
-  # 3.3 Use AI and MCP - see below.
-  ```
+```bash
+# 3.1 Use WEB Dashboard:
+uvx cocosearch dashboard
+# 3.2 Use CLI:
+uvx cocosearch index .
+# 3.3 Use AI and MCP - see below.
+```
 
 - **Register with your AI assistant (pick one)**:
 
-  **Option A — Plugin (recommended):**
+**Option A — Plugin (recommended):**
 
-  ```bash
-  claude plugin marketplace add VioletCranberry/coco-s
-  claude plugin install cocosearch@cocosearch
-  # All 7 skills + MCP server configured automatically:
+```bash
+claude plugin marketplace add VioletCranberry/coco-s
+claude plugin install cocosearch@cocosearch
+# All skills + MCP server configured automatically
+```
 
-  ❯ skills
+**Option B — Manual MCP registration:**
 
-  ⏺ Here are the available skills:
+```bash
+claude mcp add --scope user cocosearch -- uvx cocosearch mcp --project-from-cwd
+```
 
-    CocoSearch
-
-    - /cocosearch:cocosearch-quickstart — First-time setup and verification
-    - /cocosearch:cocosearch-onboarding — Guided codebase tour
-    - /cocosearch:cocosearch-debugging — Root cause analysis using CocoSearch
-    - /cocosearch:cocosearch-refactoring — Impact analysis and safe refactoring
-    - /cocosearch:cocosearch-new-feature — Pattern-matching feature development
-    - /cocosearch:cocosearch-subway — Codebase visualization as subway map
-  ```
-
-  **Option B — Manual MCP registration:**
-
-  ```bash
-  claude mcp add --scope user cocosearch -- \
-    uvx cocosearch mcp --project-from-cwd
-  ```
-
-  > **Note:** The MCP server automatically opens a web dashboard in your browser on a random port. Set `COCOSEARCH_DASHBOARD_PORT=8080` to pin it to a fixed port, or `COCOSEARCH_NO_DASHBOARD=1` to disable it.
-
-  Install skills manually (for development):
-
-  ```bash
-  mkdir -p .claude/skills
-  for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway; do
-      ln -sfn "../../skills/$skill" ".claude/skills/$skill"
-  done
-  ```
+> **Note:** The MCP server automatically opens a web dashboard in your browser on a random port. Set `COCOSEARCH_DASHBOARD_PORT=8080` to pin it to a fixed port, or `COCOSEARCH_NO_DASHBOARD=1` to disable it.
 
 - **AI Chat from the dashboard** (optional):
 
-  > **Note:** AI Chat is only available when running `cocosearch dashboard` directly. It is not available through the MCP server.
+> **Note:** AI Chat is only available when running `cocosearch dashboard` directly. It is not available through the MCP server.
 
-  ```bash
-  # Option A — run directly (no persistent install):
-  uvx "cocosearch[web-chat]" dashboard
+```bash
+# Option A — run directly (no persistent install):
+uvx "cocosearch[web-chat]" dashboard
 
-  # Option B — install persistently, then run:
-  uv tool install "cocosearch[web-chat]"
-  cocosearch dashboard
+# Option B — install persistently, then run:
+uv tool install "cocosearch[web-chat]"
+cocosearch dashboard
 
-  # Requires `claude` CLI on PATH (Claude Code users).
-  # Then open the dashboard and switch to the "Ask AI" tab.
-  ```
+# Requires `claude` CLI on PATH (Claude Code users).
+# Then open the dashboard and switch to the "Ask AI" tab.
+```
 
 ## Interfaces
 
@@ -311,6 +290,8 @@ For codebases of meaningful size, CocoSearch reduces the number of MCP tool call
 - **cocosearch-new-feature** ([SKILL.md](./skills/cocosearch-new-feature/SKILL.md)): Use when adding new functionality — a new command, endpoint, module, handler, or capability. Guides placement, pattern matching, and integration using CocoSearch.
 - **cocosearch-explore** ([SKILL.md](./skills/cocosearch-explore/SKILL.md)): Use for codebase exploration — answering questions about how code works, tracing flows, or researching a topic. Autonomous mode for subagent/plan mode research; interactive mode for user-facing "how does X work?" explanations.
 - **cocosearch-subway** ([SKILL.md](./skills/cocosearch-subway/SKILL.md)): Use when the user wants to visualize codebase structure as an interactive London Underground-style subway map. AI-generated visualization using CocoSearch tools for exploration.
+- **cocosearch-add-language** ([SKILL.md](./skills/cocosearch-add-language/SKILL.md)): Use when adding support for a new programming language or config format. Guides through handlers, symbol extraction, and context expansion with registration checklists.
+- **cocosearch-add-grammar** ([SKILL.md](./skills/cocosearch-add-grammar/SKILL.md)): Use when adding a grammar handler for domain-specific formats within a base language (e.g., GitHub Actions within YAML). Guides matches() design, separator spec, metadata extraction, and testing.
 
 ## How Search Works
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,8 @@ Reusable AI coding assistant skills that leverage CocoSearch's semantic and symb
 | [cocosearch-refactoring](./cocosearch-refactoring/SKILL.md) | Safe refactoring: full impact analysis, dependency mapping, step-by-step execution | Yes |
 | [cocosearch-new-feature](./cocosearch-new-feature/SKILL.md) | Add new functionality: find patterns, match conventions, integrate | Yes |
 | [cocosearch-subway](./cocosearch-subway/SKILL.md) | Visualize codebase as an interactive London Underground-style subway map | Yes |
-| [cocosearch-add-language](./cocosearch-add-language/SKILL.md) | Add language support: handlers, symbol extraction, grammars, context expansion | Yes |
+| [cocosearch-add-language](./cocosearch-add-language/SKILL.md) | Add language support: handlers, symbol extraction, context expansion | Yes |
+| [cocosearch-add-grammar](./cocosearch-add-grammar/SKILL.md) | Add grammar handler: domain-specific formats within a base language | Yes |
 
 ## Installation
 
@@ -24,7 +25,7 @@ claude plugin marketplace add VioletCranberry/coco-s
 claude plugin install cocosearch@cocosearch
 ```
 
-This automatically configures the MCP server and all 8 skills. No symlinks or manual setup needed.
+This automatically configures the MCP server and all 9 skills. No symlinks or manual setup needed.
 
 ### Claude Code (project-local)
 
@@ -32,7 +33,7 @@ Symlink skills from a cloned CocoSearch repo into your project:
 
 ```bash
 mkdir -p .claude/skills
-for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language; do
+for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language cocosearch-add-grammar; do
     ln -sfn "../../skills/$skill" ".claude/skills/$skill"
 done
 ```
@@ -42,7 +43,7 @@ done
 Copy skills to your global Claude config:
 
 ```bash
-for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language; do
+for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language cocosearch-add-grammar; do
     mkdir -p ~/.claude/skills/$skill
     cp skills/$skill/SKILL.md ~/.claude/skills/$skill/SKILL.md
 done
@@ -53,7 +54,7 @@ done
 Copy skills to your OpenCode config:
 
 ```bash
-for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language; do
+for skill in cocosearch-onboarding cocosearch-refactoring cocosearch-debugging cocosearch-quickstart cocosearch-explore cocosearch-new-feature cocosearch-subway cocosearch-add-language cocosearch-add-grammar; do
     mkdir -p ~/.config/opencode/skills/$skill
     cp skills/$skill/SKILL.md ~/.config/opencode/skills/$skill/SKILL.md
 done

--- a/skills/cocosearch-add-grammar/SKILL.md
+++ b/skills/cocosearch-add-grammar/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: cocosearch-add-grammar
+description: Use when adding a grammar handler for domain-specific file formats that share a base language extension (e.g., GitHub Actions within YAML). Guides through matches() design, separator spec, metadata extraction, tests, and registration.
+---
+
+# Add Grammar Handler with CocoSearch
+
+A structured workflow for adding a grammar handler to CocoSearch. Grammar handlers provide domain-specific chunking and metadata for files that share a base language extension but have distinct structure (e.g., GitHub Actions workflows are YAML files with a specific schema).
+
+**Philosophy:** The hardest part of a grammar handler is the `matches()` method — getting path/content detection right so it claims the right files without conflicting with other grammars. This skill provides a decision tree to get it right the first time.
+
+**Reference:** `docs/adding-languages.md` covers grammar handlers alongside language handlers. This skill is the dedicated deep-dive for grammars.
+
+## Step 1: Identify the Grammar
+
+Parse the user's request to determine what's being added.
+
+**Extract from the request:**
+
+- **Grammar name:** Lowercase hyphenated identifier (e.g., `github-actions`, `docker-compose`, `ansible-playbook`)
+- **Base language:** The language this grammar extends (e.g., `yaml`, `json`, `toml`)
+- **File path patterns:** Glob patterns matching file paths (e.g., `.github/workflows/*.yml`, `docker-compose*.yml`)
+- **Content markers:** Strings that distinguish this grammar from other files with the same extension (e.g., `on:` + `jobs:` for GitHub Actions, `apiVersion:` + `kind:` for Kubernetes)
+
+**Confirm with user:** "I'll add a grammar handler for [grammar] (base: [language]) matching [patterns]. Let me find the best analog."
+
+## Step 2: Find the Best Analog
+
+Choose the closest existing grammar handler based on the grammar type:
+
+| Grammar Type | Analog | Why |
+|---|---|---|
+| CI/CD pipeline (YAML) | `github_actions.py` or `gitlab_ci.py` | Jobs/stages/steps structure |
+| Container orchestration (YAML) | `docker_compose.py` or `kubernetes.py` | Services/resources structure |
+| Template (YAML/gotmpl) | `helm_template.py` or `helm_values.py` | Template directives + values |
+| Kubernetes manifest (YAML) | `kubernetes.py` | Content-heavy matching with exclusions |
+| Config values (YAML) | `helm_values.py` | Comment-based section markers |
+
+> **Non-YAML grammars:** The pattern applies equally to JSON, TOML, or XML base languages — adapt `PATH_PATTERNS` and content markers accordingly. All 6 existing grammars use YAML/gotmpl, but the handler structure is language-agnostic.
+
+Search for and read the analog handler:
+
+```
+search_code(
+    query="<analog-grammar> grammar handler GRAMMAR_NAME matches",
+    symbol_type="class",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+Read the analog handler fully before proceeding.
+
+## Step 3: Design the `matches()` Method
+
+This is the critical step. Use the decision tree to determine the right matching strategy:
+
+```
+Are your PATH_PATTERNS specific to this grammar?
+(e.g., ".github/workflows/*.yml", ".gitlab-ci.yml", "docker-compose*.yml")
+
+YES --> Path-specific matching
+  - fnmatch against PATH_PATTERNS (with nested path support via */pattern)
+  - Content check is OPTIONAL (confirmatory, improves accuracy)
+  - Return True when path matches and content is None
+  - Example: GitHubActionsHandler -- ".github/workflows/*.yml" is specific enough
+
+NO --> Broad patterns that match many files
+(e.g., "*.yaml", "*.yml")
+
+  - Content check is MANDATORY
+  - Return False when content is None (can't distinguish without content)
+  - Must check for positive markers (e.g., "apiVersion:" + "kind:")
+  - Must check for negative markers (exclude other grammars' files)
+  - Example: KubernetesHandler -- "*.yaml" matches everything, so content is required
+```
+
+### Path-specific matching pattern
+
+```python
+def matches(self, filepath: str, content: str | None = None) -> bool:
+    for pattern in self.PATH_PATTERNS:
+        if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(
+            filepath, f"*/{pattern}"
+        ):
+            if content is not None:
+                # Optional: confirm with content markers
+                return "marker_a:" in content and "marker_b:" in content
+            return True  # Path is specific enough
+    return False
+```
+
+### Broad pattern matching (content required)
+
+```python
+def matches(self, filepath: str, content: str | None = None) -> bool:
+    basename = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+    for pattern in self.PATH_PATTERNS:
+        if fnmatch.fnmatch(basename, pattern):
+            if content is None:
+                return False  # Can't distinguish without content
+            # Positive markers
+            if "required_key:" not in content:
+                return False
+            # Negative markers (exclude competing grammars)
+            if any(marker in content for marker in _COMPETING_MARKERS):
+                return False
+            return True
+    return False
+```
+
+### Conflict avoidance
+
+When multiple grammars share broad patterns (`*.yaml`, `*.yml`), check for markers from competing grammars:
+
+- **Kubernetes** excludes Helm markers via `_HELM_MARKERS` import from `helm_template.py`
+- **Docker Compose** uses path-specific patterns (`docker-compose*.yml`) to avoid overlap
+- **GitLab CI** uses an exact filename (`.gitlab-ci.yml`) to avoid overlap
+
+Search for potential conflicts:
+
+```
+search_code(
+    query="PATH_PATTERNS matches grammar handler yaml yml",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+Review all existing grammar `PATH_PATTERNS` and `matches()` logic to ensure your new grammar won't claim files that belong to another grammar.
+
+## Step 4: Create the Handler File
+
+1. **Copy** `src/cocosearch/handlers/grammars/_template.py` to `<grammar>.py`
+2. **Rename** the class to `<Grammar>Handler` (e.g., `AnsiblePlaybookHandler`)
+3. **Set** `GRAMMAR_NAME` -- unique lowercase hyphenated identifier (e.g., `ansible-playbook`)
+4. **Set** `BASE_LANGUAGE` -- the base language (e.g., `"yaml"`)
+5. **Set** `PATH_PATTERNS` -- glob patterns matching file paths
+6. **Implement** `matches(filepath, content)` -- per decision tree in Step 3
+7. **Define** `SEPARATOR_SPEC` with `CustomLanguageSpec` -- hierarchical regex separators from coarsest to finest
+8. **Implement** `extract_metadata(text)` returning `block_type`, `hierarchy`, and `language_id`
+
+**Separator constraints:** Use standard regex only -- no lookaheads/lookbehinds (CocoIndex uses Rust regex).
+
+**Autodiscovery:** The grammar is autodiscovered at import time. Any `handlers/grammars/*.py` file (not prefixed with `_`) implementing the grammar handler protocol is auto-registered. No registration code needed.
+
+### Metadata extraction tips
+
+- Strip leading comments before analysis (use `strip_leading_comments` from `cocosearch.handlers.utils`)
+- Identify the most meaningful block types (e.g., "job", "step", "service", "resource")
+- Build `hierarchy` as a structured path (e.g., `"job:build"`, `"service:web"`, `"kind:Deployment"`)
+- Always set `language_id` to `self.GRAMMAR_NAME`
+- Return empty strings for unrecognized content (not `None`)
+
+## Step 5: Create Tests
+
+Create `tests/unit/handlers/grammars/test_<grammar>.py` following the 4-class test pattern from existing grammars:
+
+### TestMatching
+
+- **Path matching (positive):** Files matching PATH_PATTERNS are detected
+- **Path matching (negative):** Non-matching paths are rejected
+- **Nested paths:** Patterns work when nested under parent directories (e.g., `project/.github/workflows/ci.yml`)
+- **Content matching (positive):** Content with correct markers is detected
+- **Content matching (negative):** Content without markers is rejected
+- **`content=None` behavior:** Returns True for path-specific grammars, False for broad-pattern grammars
+
+### TestSeparatorSpec
+
+- `language_name` matches `GRAMMAR_NAME`
+- `separators_regex` is non-empty
+- No lookaheads/lookbehinds in regex patterns (assert `(?=`, `(?!`, `(?<=`, `(?<!` not in separators)
+
+### TestExtractMetadata
+
+- Each block type returns correct `block_type` and `hierarchy`
+- Comments are stripped before analysis
+- Unrecognized content returns empty strings as fallback
+- `language_id` always equals `GRAMMAR_NAME`
+
+### TestProtocol
+
+- `GRAMMAR_NAME` is set and non-empty
+- `BASE_LANGUAGE` is set and non-empty
+- `PATH_PATTERNS` is a non-empty list
+
+Find the analog's test file for the exact pattern:
+
+```
+search_code(
+    query="test <analog-grammar> grammar matching separator metadata",
+    symbol_type="class",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+**Checkpoint with user:** "Grammar handler created at `src/cocosearch/handlers/grammars/<grammar>.py` with [path-specific/broad] matching. Tests pass. Ready for count assertions and documentation?"
+
+## Step 6: Update Count Assertions
+
+> **This is the most commonly missed step.** Do not skip.
+
+### 6a. Grammar Count
+
+```
+search_code(
+    query="test grammar registry count _GRAMMAR_REGISTRY",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+Update in `tests/unit/handlers/test_grammar_registry.py`:
+- `len(_GRAMMAR_REGISTRY) == N` -- increment by 1
+- Grammar name in the expected names set -- add the new grammar name
+- `len(grammars) == N` from `get_registered_grammars()` -- increment by 1
+
+### 6b. Combined Spec Count
+
+```
+search_code(
+    query="test_returns_twelve_specs get_all_custom_language_specs",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+Update in `tests/unit/handlers/test_registry.py`:
+- `len(specs) == N` from `get_all_custom_language_specs()` -- increment by 1 (this is the combined total of all language handler specs + grammar handler specs)
+
+## Step 7: Update Documentation
+
+### 7a. CLAUDE.md
+
+Update module descriptions and counts:
+- Handler count in Architecture section (e.g., "Total custom language specs: N")
+- Grammar handler list in the `handlers/` module description
+- Any handler/grammar counts mentioned
+
+### 7b. README.md
+
+```
+search_code(
+    query="Supported Grammars grammar table badges",
+    use_hybrid_search=True,
+    smart_context=True
+)
+```
+
+Update:
+- Grammar badge row in the badge section
+- Grammar table with new entry (grammar name, file format, path patterns)
+- Grammar count in prose (if mentioned)
+
+### 7c. docs/adding-languages.md
+
+If the new grammar introduces a novel matching pattern (e.g., first non-YAML grammar, first content-only match without path patterns), add it as a worked example.
+
+## Step 8: Verify
+
+### 8a. Run Tests
+
+```bash
+# Grammar tests
+uv run pytest tests/unit/handlers/grammars/test_<grammar>.py -v
+
+# Registry count assertions
+uv run pytest tests/unit/handlers/test_registry.py -v
+uv run pytest tests/unit/handlers/test_grammar_registry.py -v
+
+# Full handler test suite
+uv run pytest tests/unit/handlers/ -v
+```
+
+### 8b. Lint
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+```
+
+### 8c. Present Summary
+
+```
+Grammar handler added for [grammar]!
+
+Handler: src/cocosearch/handlers/grammars/<grammar>.py
+  - Grammar name: <grammar-name>
+  - Base language: <base-language>
+  - Path patterns: <patterns>
+  - Matching strategy: <path-specific/broad with content validation>
+  - Separator levels: <N>
+
+Registration points:
+  [x] Grammar handler file created (autodiscovered)
+  [x] Tests created (tests/unit/handlers/grammars/test_<grammar>.py)
+  [x] test_grammar_registry.py counts updated
+  [x] test_registry.py combined spec count updated
+  [x] CLAUDE.md updated
+  [x] README.md updated
+
+Tests: PASS
+Lint: PASS
+
+To try it out:
+  uv run cocosearch grammars          # Verify grammar appears
+  uv run cocosearch index .           # Reindex to pick up grammar-matched files
+  uv run cocosearch search "query" --language <grammar-name>
+```
+
+## Registration Checklist
+
+Complete checklist of all registration points. Check off each one as you complete it:
+
+- [ ] `src/cocosearch/handlers/grammars/<grammar>.py` created
+- [ ] `tests/unit/handlers/grammars/test_<grammar>.py` created
+- [ ] `tests/unit/handlers/test_grammar_registry.py` -- grammar count and name set updated
+- [ ] `tests/unit/handlers/test_registry.py` -- combined spec count updated
+- [ ] `CLAUDE.md` -- grammar handler list and counts updated
+- [ ] `README.md` -- grammar table and badges updated
+
+For common search tips (hybrid search, smart_context, symbol filtering), see `skills/README.md`.
+
+For the full language support workflow (handlers, symbols, context expansion), use `/cocosearch:cocosearch-add-language`.

--- a/skills/cocosearch-add-language/SKILL.md
+++ b/skills/cocosearch-add-language/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cocosearch-add-language
-description: Use when adding support for a new programming language, config format, or grammar to CocoSearch. Guides through all paths (handler, symbol extraction, grammar, context expansion) with registration checklists.
+description: Use when adding support for a new programming language or config format to CocoSearch. Guides through all paths (handler, symbol extraction, context expansion) with registration checklists. For grammar handlers, use cocosearch-add-grammar.
 ---
 
 # Add Language Support with CocoSearch
@@ -10,14 +10,6 @@ A structured workflow for adding language support to CocoSearch. Navigates up to
 **Philosophy:** The most common failure when adding language support is missing a registration step. This skill makes that impossible by tracking every step explicitly.
 
 **Reference:** `docs/adding-languages.md` is the authoritative technical guide. This skill wraps it in an interactive workflow.
-
-## Pre-flight Check
-
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
-2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index -> offer to index before proceeding
-- Stale (>7 days) -> warn: "Index is X days old -- I may miss recent patterns. Want me to reindex first?"
 
 ## Step 1: Identify the Language
 
@@ -309,48 +301,13 @@ Create `tests/unit/indexer/symbols/test_<language>.py` covering:
 
 > **Skip this step** unless the language is a domain-specific schema sharing a base language extension.
 
-### 5a. Find the Best Analog Grammar
+For grammar handler implementation, use the dedicated skill:
 
-| Grammar Type | Analog | Why |
-|-------------|--------|-----|
-| CI/CD pipeline (YAML) | `github_actions.py` or `gitlab_ci.py` | Jobs/stages/steps structure |
-| Container orchestration (YAML) | `docker_compose.py` or `kubernetes.py` | Services/resources structure |
-| Template (YAML) | `helm_template.py` or `helm_values.py` | Template directives + values |
+**Invoke:** `/cocosearch:cocosearch-add-grammar`
 
-Search for the analog:
+This skill provides in-depth guidance for `matches()` design, separator spec, metadata extraction, conflict avoidance, and grammar-specific testing.
 
-```
-search_code(
-    query="<analog-grammar> grammar handler GRAMMAR_NAME matches",
-    symbol_type="class",
-    use_hybrid_search=True,
-    smart_context=True
-)
-```
-
-### 5b. Create the Grammar Handler File
-
-1. **Create** `src/cocosearch/handlers/grammars/<grammar>.py` (copy `_template.py`)
-2. **Set** `GRAMMAR_NAME` -- unique lowercase hyphenated identifier
-3. **Set** `BASE_LANGUAGE` -- the base language (e.g., `"yaml"`)
-4. **Set** `PATH_PATTERNS` -- glob patterns matching file paths
-5. **Implement** `matches(filepath, content)` -- path + content detection
-6. **Define** `SEPARATOR_SPEC` with `CustomLanguageSpec` (or `None` for base language defaults)
-7. **Implement** `extract_metadata(text)` returning `block_type`, `hierarchy`, and `language_id`
-
-The grammar is autodiscovered at import time; no registration code needed.
-
-### 5c. Create Grammar Tests
-
-Create `tests/unit/handlers/grammars/test_<grammar>.py` covering:
-- Grammar properties (name, base language, path patterns)
-- Separator spec
-- Path matching (positive and negative cases)
-- Content matching (positive and negative cases)
-- Metadata extraction
-- Edge cases (no content provided, wrong path, wrong content markers)
-
-**Checkpoint with user:** "Grammar handler created for [grammar]. Tests pass. Ready for documentation updates?"
+After completing the grammar skill, return here for Step 7 (count assertions) and Step 8 (documentation).
 
 ## Step 6: Context Expansion (Path E)
 


### PR DESCRIPTION
Split grammar handler guidance from cocosearch-add-language into a dedicated cocosearch-add-grammar skill. Update README table of contents to include MCP Tools and Skills subsections, flatten the skills list, and clean up Quick Start formatting. Update skill counts and references across CLAUDE.md, skills/README.md, and installation instructions.