### PR TITLE
fix: handle missing readline module on Windows

### DIFF
--- a/src/cocosearch/search/repl.py
+++ b/src/cocosearch/search/repl.py
@@ -6,7 +6,11 @@ needing to restart the CLI for each query.
 
 import cmd
 import re
-import readline  # noqa: F401 - Enables history/editing
+
+try:
+    import readline  # noqa: F401 - Enables history/editing in cmd.Cmd
+except ImportError:
+    pass  # readline unavailable on Windows; history/editing won't work
 
 from rich.console import Console
 


### PR DESCRIPTION
The `readline` stdlib module is Unix-only and causes ModuleNotFoundError on Windows. Wrap the import in try/except since it's only used for the side effect of enabling history and arrow key editing in cmd.Cmd.