### PR TITLE
fix: make skills resilient to missing cocosearch.yaml

### DIFF
--- a/skills/cocosearch-commit/SKILL.md
+++ b/skills/cocosearch-commit/SKILL.md
@@ -17,10 +17,12 @@ A structured workflow for generating comprehensive commit messages. Uses CocoSea
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- warn: "No CocoSearch index found. I'll generate a commit message from diffs alone, but semantic analysis won't be available. Want me to index first?" Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-   - No index -> warn: "No CocoSearch index found. I'll generate a commit message from diffs alone, but semantic analysis won't be available. Want me to index first?"
+3. `index_stats(index_name="<resolved-name>")` to check freshness
    - Stale (>7 days) -> warn: "Index is X days old -- semantic context may not reflect recent changes."
 4. Check dependency freshness -- call `get_file_dependencies` on any known file:
 

--- a/skills/cocosearch-debugging/SKILL.md
+++ b/skills/cocosearch-debugging/SKILL.md
@@ -7,9 +7,12 @@ description: Use when debugging an error, unexpected behavior, or tracing how co
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - No index → offer to index before debugging
 - Stale (>7 days) → warn: "Index is X days old -- results may not reflect recent changes. Want me to reindex first?"
 4. Check dependency freshness — call `get_file_dependencies` on any known file from the error context:

--- a/skills/cocosearch-deps/SKILL.md
+++ b/skills/cocosearch-deps/SKILL.md
@@ -20,7 +20,10 @@ A guided workflow for understanding how files connect through dependencies. Use 
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
 3. Verify dependency index exists and is fresh — call `get_file_dependencies` on any known file:
 

--- a/skills/cocosearch-explore/SKILL.md
+++ b/skills/cocosearch-explore/SKILL.md
@@ -33,10 +33,12 @@ A unified exploration skill with two modes:
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- **Autonomous:** return FAILED status immediately. **Interactive:** offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → **Autonomous:** return FAILED status immediately. **Interactive:** offer to index.
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → note in output, proceed with warning
 
 ---

--- a/skills/cocosearch-new-feature/SKILL.md
+++ b/skills/cocosearch-new-feature/SKILL.md
@@ -11,10 +11,12 @@ A systematic workflow for adding new code to an existing codebase. This skill us
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → offer to index before proceeding
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → warn: "Index is X days old -- I may miss recent patterns. Want me to reindex first?"
 
 ## Step 1: Understand the Feature

--- a/skills/cocosearch-onboarding/SKILL.md
+++ b/skills/cocosearch-onboarding/SKILL.md
@@ -13,14 +13,17 @@ Before we start exploring, let me check if we have a CocoSearch index for this c
 
 **I'll run:**
 
-1. **Check for project config first:** Look for `cocosearch.yaml` in the project root. If it exists and has an `indexName` field, use that as the index name for all subsequent operations. **This is critical** — the MCP `index_codebase` tool auto-derives names from the directory path if `index_name` is not specified, which may not match the configured name. A mismatch causes "Index not found" errors from the CLI.
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` - Check what indexes exist
-3. `index_stats(index_name="<configured-name>")` - Check index health and freshness
+3. `index_stats(index_name="<resolved-name>")` - Check index health and freshness
 
 **What to look for:**
 
-- **No index found:** I'll offer to run `index_codebase(path, index_name="<configured-name>")` to create one before we start. **Always pass `index_name` explicitly** to match the project config.
-- **Index exists but stale (>7 days):** I'll mention the index might be outdated and ask if you want to reindex for the freshest results
+- **No index found:** Offer to run `index_codebase(path, index_name="<resolved-name>")` to create one before we start.
+- **Index exists but stale (>7 days):** Mention the index might be outdated and ask if you want to reindex for the freshest results
 - **Index fresh:** Great! We can start exploring immediately
 
 **Why this matters:** Stale indexes might miss recent refactorings or new modules. A fresh index gives you the most accurate picture of the codebase.

--- a/skills/cocosearch-quickstart/SKILL.md
+++ b/skills/cocosearch-quickstart/SKILL.md
@@ -54,7 +54,10 @@ This starts both PostgreSQL and Ollama in one command.
 
 ## Step 2: Index the Project
 
-**First, check for project config:** Look for `cocosearch.yaml` in the project root. If it exists and has an `indexName` field, use that as the index name for all subsequent operations. **This is critical** — the MCP `index_codebase` tool auto-derives names from the directory path if `index_name` is not specified, which may not match the configured name. A mismatch causes "Index not found" errors from the CLI.
+**Resolve index name** (use the resolved name for all operations):
+- **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+- **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+- **If no match found**, the project is genuinely not indexed -- proceed to create one below. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 
 **Check if an index already exists for this project:**
 
@@ -63,17 +66,17 @@ list_indexes()
 ```
 
 **If index exists:**
-- Run `index_stats(index_name="<configured-name>")` to check freshness
+- Run `index_stats(index_name="<resolved-name>")` to check freshness
 - If stale (>7 days): ask "Index is X days old. Reindex to pick up recent changes?"
 - If fresh: skip to Step 3
 
 **If no index exists, create one:**
 
 ```
-index_codebase(path="<current-project-root>", index_name="<configured-name>")
+index_codebase(path="<current-project-root>", index_name="<resolved-name>")
 ```
 
-**Always pass `index_name` explicitly** to match the project config. If no `cocosearch.yaml` exists, the auto-derived name is fine. Indexing will:
+Indexing will:
 - Discover all supported files (Python, TypeScript, Go, Rust, Java, C/C++, HCL, Dockerfile, Bash, Markdown, YAML)
 - Parse symbols via Tree-sitter (functions, classes, methods)
 - Generate embeddings via the configured provider (ollama/nomic-embed-text by default)

--- a/skills/cocosearch-refactoring/SKILL.md
+++ b/skills/cocosearch-refactoring/SKILL.md
@@ -11,10 +11,12 @@ A systematic workflow for safe code refactoring. This skill guides you through c
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- indexing is REQUIRED. Refactoring needs 100% accurate dependency data. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → indexing is REQUIRED. Refactoring needs 100% accurate dependency data.
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → **strongly recommend reindexing**. Stale data can miss critical dependencies.
 4. Check dependency freshness — call `get_file_dependencies` on the target file (or any known file):
 

--- a/skills/cocosearch-review-pr/SKILL.md
+++ b/skills/cocosearch-review-pr/SKILL.md
@@ -17,7 +17,10 @@ A structured workflow for reviewing pull requests (GitHub) or merge requests (Gi
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. **Inventory API tokens.** Check which tokens are available before anything else:
 
    ```bash
@@ -60,6 +63,8 @@ A structured workflow for reviewing pull requests (GitHub) or merge requests (Gi
 8. Verify API access with a lightweight call (fetch PR/MR metadata -- Step 1 below). If it fails with 401/403, report the auth error and stop.
 
 ## Step 1: Fetch PR/MR Data
+
+> **Important:** Use the Python `urllib` / `curl` snippets provided below for all API calls. Do NOT use `gh`, `glab`, or other CLI wrappers -- they may not be installed and add an unnecessary dependency.
 
 ### GitHub
 

--- a/src/cocosearch/skills/cocosearch-commit/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-commit/SKILL.md
@@ -17,10 +17,12 @@ A structured workflow for generating comprehensive commit messages. Uses CocoSea
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- warn: "No CocoSearch index found. I'll generate a commit message from diffs alone, but semantic analysis won't be available. Want me to index first?" Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-   - No index -> warn: "No CocoSearch index found. I'll generate a commit message from diffs alone, but semantic analysis won't be available. Want me to index first?"
+3. `index_stats(index_name="<resolved-name>")` to check freshness
    - Stale (>7 days) -> warn: "Index is X days old -- semantic context may not reflect recent changes."
 4. Check dependency freshness -- call `get_file_dependencies` on any known file:
 

--- a/src/cocosearch/skills/cocosearch-debugging/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-debugging/SKILL.md
@@ -7,9 +7,12 @@ description: Use when debugging an error, unexpected behavior, or tracing how co
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - No index → offer to index before debugging
 - Stale (>7 days) → warn: "Index is X days old -- results may not reflect recent changes. Want me to reindex first?"
 4. Check dependency freshness — call `get_file_dependencies` on any known file from the error context:

--- a/src/cocosearch/skills/cocosearch-deps/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-deps/SKILL.md
@@ -20,7 +20,10 @@ A guided workflow for understanding how files connect through dependencies. Use 
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
 3. Verify dependency index exists and is fresh — call `get_file_dependencies` on any known file:
 

--- a/src/cocosearch/skills/cocosearch-explore/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-explore/SKILL.md
@@ -33,10 +33,12 @@ A unified exploration skill with two modes:
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- **Autonomous:** return FAILED status immediately. **Interactive:** offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → **Autonomous:** return FAILED status immediately. **Interactive:** offer to index.
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → note in output, proceed with warning
 
 ---

--- a/src/cocosearch/skills/cocosearch-new-feature/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-new-feature/SKILL.md
@@ -11,10 +11,12 @@ A systematic workflow for adding new code to an existing codebase. This skill us
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → offer to index before proceeding
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → warn: "Index is X days old -- I may miss recent patterns. Want me to reindex first?"
 
 ## Step 1: Understand the Feature

--- a/src/cocosearch/skills/cocosearch-onboarding/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-onboarding/SKILL.md
@@ -13,14 +13,17 @@ Before we start exploring, let me check if we have a CocoSearch index for this c
 
 **I'll run:**
 
-1. **Check for project config first:** Look for `cocosearch.yaml` in the project root. If it exists and has an `indexName` field, use that as the index name for all subsequent operations. **This is critical** — the MCP `index_codebase` tool auto-derives names from the directory path if `index_name` is not specified, which may not match the configured name. A mismatch causes "Index not found" errors from the CLI.
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` - Check what indexes exist
-3. `index_stats(index_name="<configured-name>")` - Check index health and freshness
+3. `index_stats(index_name="<resolved-name>")` - Check index health and freshness
 
 **What to look for:**
 
-- **No index found:** I'll offer to run `index_codebase(path, index_name="<configured-name>")` to create one before we start. **Always pass `index_name` explicitly** to match the project config.
-- **Index exists but stale (>7 days):** I'll mention the index might be outdated and ask if you want to reindex for the freshest results
+- **No index found:** Offer to run `index_codebase(path, index_name="<resolved-name>")` to create one before we start.
+- **Index exists but stale (>7 days):** Mention the index might be outdated and ask if you want to reindex for the freshest results
 - **Index fresh:** Great! We can start exploring immediately
 
 **Why this matters:** Stale indexes might miss recent refactorings or new modules. A fresh index gives you the most accurate picture of the codebase.

--- a/src/cocosearch/skills/cocosearch-quickstart/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-quickstart/SKILL.md
@@ -54,7 +54,10 @@ This starts both PostgreSQL and Ollama in one command.
 
 ## Step 2: Index the Project
 
-**First, check for project config:** Look for `cocosearch.yaml` in the project root. If it exists and has an `indexName` field, use that as the index name for all subsequent operations. **This is critical** — the MCP `index_codebase` tool auto-derives names from the directory path if `index_name` is not specified, which may not match the configured name. A mismatch causes "Index not found" errors from the CLI.
+**Resolve index name** (use the resolved name for all operations):
+- **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+- **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+- **If no match found**, the project is genuinely not indexed -- proceed to create one below. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 
 **Check if an index already exists for this project:**
 
@@ -63,17 +66,17 @@ list_indexes()
 ```
 
 **If index exists:**
-- Run `index_stats(index_name="<configured-name>")` to check freshness
+- Run `index_stats(index_name="<resolved-name>")` to check freshness
 - If stale (>7 days): ask "Index is X days old. Reindex to pick up recent changes?"
 - If fresh: skip to Step 3
 
 **If no index exists, create one:**
 
 ```
-index_codebase(path="<current-project-root>", index_name="<configured-name>")
+index_codebase(path="<current-project-root>", index_name="<resolved-name>")
 ```
 
-**Always pass `index_name` explicitly** to match the project config. If no `cocosearch.yaml` exists, the auto-derived name is fine. Indexing will:
+Indexing will:
 - Discover all supported files (Python, TypeScript, Go, Rust, Java, C/C++, HCL, Dockerfile, Bash, Markdown, YAML)
 - Parse symbols via Tree-sitter (functions, classes, methods)
 - Generate embeddings via the configured provider (ollama/nomic-embed-text by default)

--- a/src/cocosearch/skills/cocosearch-refactoring/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-refactoring/SKILL.md
@@ -11,10 +11,12 @@ A systematic workflow for safe code refactoring. This skill guides you through c
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- indexing is REQUIRED. Refactoring needs 100% accurate dependency data. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. `list_indexes()` to confirm project is indexed
-3. `index_stats(index_name="<configured-name>")` to check freshness
-- No index → indexing is REQUIRED. Refactoring needs 100% accurate dependency data.
+3. `index_stats(index_name="<resolved-name>")` to check freshness
 - Stale (>7 days) → **strongly recommend reindexing**. Stale data can miss critical dependencies.
 4. Check dependency freshness — call `get_file_dependencies` on the target file (or any known file):
 

--- a/src/cocosearch/skills/cocosearch-review-pr/SKILL.md
+++ b/src/cocosearch/skills/cocosearch-review-pr/SKILL.md
@@ -17,7 +17,10 @@ A structured workflow for reviewing pull requests (GitHub) or merge requests (Gi
 
 ## Pre-flight Check
 
-1. Read `cocosearch.yaml` for `indexName` (critical -- use this for all operations)
+1. **Resolve index name** (use the resolved name for all operations):
+   - **Try** `cocosearch.yaml` for `indexName` field -- if found, use it
+   - **If no config file**, call `list_indexes()` and match the current project's directory name against available indexes. The MCP tools auto-derive index names from directory paths (e.g., `my-project/` -> `my_project`), so a match is likely if the repo was indexed without a config file.
+   - **If no match found**, the project is genuinely not indexed -- offer to index it. Do NOT abandon CocoSearch tools just because `cocosearch.yaml` is missing.
 2. **Inventory API tokens.** Check which tokens are available before anything else:
 
    ```bash
@@ -60,6 +63,8 @@ A structured workflow for reviewing pull requests (GitHub) or merge requests (Gi
 8. Verify API access with a lightweight call (fetch PR/MR metadata -- Step 1 below). If it fails with 401/403, report the auth error and stop.
 
 ## Step 1: Fetch PR/MR Data
+
+> **Important:** Use the Python `urllib` / `curl` snippets provided below for all API calls. Do NOT use `gh`, `glab`, or other CLI wrappers -- they may not be installed and add an unnecessary dependency.
 
 ### GitHub
 


### PR DESCRIPTION
Skills previously treated cocosearch.yaml as a hard requirement — when absent, AI assistants would abandon CocoSearch tools entirely even if the repo was indexed under an auto-derived name. Replace the rigid "read config or bail" step with a 3-tier fallback: try config, then list_indexes() match by directory name, then offer to index. Also add explicit gh/glab CLI prohibition to the PR review skill.