### PR TITLE
fix(deps): anchor index resolution to target path; add fresh deps exraction

### DIFF
--- a/src/cocosearch/cli.py
+++ b/src/cocosearch/cli.py
@@ -112,8 +112,10 @@ def _resolve_index_name(
     )
     if name:
         return name, source
-    # Auto-detect: try git root first, fall back to path
-    git_index = derive_index_from_git()
+    # Auto-detect: try git root first, fall back to path. Both anchor to
+    # fallback_path (the target codebase for path-based commands) so the
+    # name reflects the project being operated on, not the caller's cwd.
+    git_index = derive_index_from_git(fallback_path)
     if git_index:
         return git_index, "git"
     return derive_index_name(fallback_path or os.getcwd()), "derived"
@@ -155,8 +157,10 @@ def index_command(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # Load config from cocosearch.yaml if present
-    config_path = find_config_file()
+    # Load config from cocosearch.yaml if present. Anchor to the target codebase
+    # so indexing /other/repo from a project dir uses that repo's config and
+    # index name, not the caller's cwd.
+    config_path = find_config_file(codebase_path)
     if config_path:
         console.print(f"[dim]Loading config from {config_path}[/dim]")
         try:
@@ -2316,7 +2320,13 @@ def deps_extract_command(args: argparse.Namespace) -> int:
     """
     console = Console()
 
-    config_path = find_config_file()
+    codebase_path = os.path.abspath(args.path)
+
+    # Anchor config and index-name resolution to the target codebase, not the
+    # caller's cwd. Otherwise `deps extract /other/repo` run from a project
+    # directory would resolve to *this* project's index and re-extract against
+    # the wrong files (with --fresh, wiping the wrong index's edges).
+    config_path = find_config_file(codebase_path)
     if config_path:
         try:
             project_config = load_project_config(config_path)
@@ -2326,9 +2336,9 @@ def deps_extract_command(args: argparse.Namespace) -> int:
         project_config = CocoSearchConfig()
 
     resolver = ConfigResolver(project_config, config_path)
-    index_name, _ = _resolve_index_name(resolver, cli_value=args.name)
-
-    codebase_path = os.path.abspath(args.path)
+    index_name, _ = _resolve_index_name(
+        resolver, cli_value=args.name, fallback_path=codebase_path
+    )
 
     fresh = getattr(args, "fresh", False)
 

--- a/src/cocosearch/config/loader.py
+++ b/src/cocosearch/config/loader.py
@@ -11,21 +11,29 @@ from .errors import format_validation_errors
 from .schema import CocoSearchConfig, ConfigError
 
 
-def find_config_file() -> Path | None:
-    """Find cocosearch.yaml in current directory or git root.
+def find_config_file(start_dir: str | Path | None = None) -> Path | None:
+    """Find cocosearch.yaml in a starting directory or its git root.
+
+    Args:
+        start_dir: Directory to anchor the search to. Defaults to the current
+            working directory. Path-based commands (``index``, ``deps extract``)
+            pass the target codebase path here so the config is resolved
+            relative to the project being operated on, not the caller's cwd.
 
     Returns:
         Path to config file, or None if not found.
     """
-    # Check current working directory first
-    cwd_config = Path.cwd() / "cocosearch.yaml"
-    if cwd_config.exists():
-        return cwd_config
+    base = Path(start_dir) if start_dir else Path.cwd()
 
-    # Try git root
+    # Check the starting directory first
+    direct_config = base / "cocosearch.yaml"
+    if direct_config.exists():
+        return direct_config
+
+    # Try git root of the starting directory
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "-C", str(base), "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             check=True,

--- a/src/cocosearch/dashboard/web/static/index.html
+++ b/src/cocosearch/dashboard/web/static/index.html
@@ -89,6 +89,7 @@
                     <button id="reindexBtn" class="action-btn">Reindex</button>
                     <button id="freshIndexBtn" class="action-btn danger">Fresh Index</button>
                     <button id="extractDepsBtn" class="action-btn">Extract Deps</button>
+                    <button id="freshExtractDepsBtn" class="action-btn danger">Fresh Extract Deps</button>
                     <button id="stopIndexBtn" class="action-btn danger" style="display: none;">Stop</button>
                     <button id="deleteIndexBtn" class="action-btn danger">Delete</button>
                 </div>

--- a/src/cocosearch/dashboard/web/static/js/app.js
+++ b/src/cocosearch/dashboard/web/static/js/app.js
@@ -35,7 +35,8 @@ document.getElementById('reindexBtn').addEventListener('click', () => reindex(fa
 document.getElementById('freshIndexBtn').addEventListener('click', () => reindex(true));
 document.getElementById('stopIndexBtn').addEventListener('click', stopIndexing);
 document.getElementById('deleteIndexBtn').addEventListener('click', deleteIndex);
-document.getElementById('extractDepsBtn').addEventListener('click', extractDeps);
+document.getElementById('extractDepsBtn').addEventListener('click', () => extractDeps(false));
+document.getElementById('freshExtractDepsBtn').addEventListener('click', () => extractDeps(true));
 
 // Search
 document.getElementById('searchInput').addEventListener('keydown', (e) => {

--- a/src/cocosearch/dashboard/web/static/js/index-mgmt.js
+++ b/src/cocosearch/dashboard/web/static/js/index-mgmt.js
@@ -468,14 +468,18 @@ export async function indexCurrentProject() {
     }
 }
 
-export async function extractDeps() {
+export async function extractDeps(fresh) {
+    if (fresh && !confirm('Fresh Extract Deps re-extracts the entire dependency graph, ignoring the incremental cache. Continue?')) {
+        return;
+    }
+
     const select = document.getElementById('indexSelect');
     const indexIndex = parseInt(select.value);
     const stats = state.allIndexes[indexIndex];
     if (!stats) return;
 
     setButtonsDisabled(true);
-    showStatusBanner('Extracting dependencies...', 'info');
+    showStatusBanner(fresh ? 'Fresh extracting dependencies...' : 'Extracting dependencies...', 'info');
 
     try {
         const resp = await fetch('/api/extract-deps', {
@@ -483,6 +487,7 @@ export async function extractDeps() {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
                 index_name: stats.name,
+                fresh: fresh,
                 source_path: stats.source_path || (state.projectContext && state.projectContext.project_path)
             })
         });

--- a/src/cocosearch/management/git.py
+++ b/src/cocosearch/management/git.py
@@ -214,16 +214,20 @@ def get_branch_commit_count(path: str | Path | None = None) -> int | None:
         return None
 
 
-def derive_index_from_git() -> str | None:
-    """Derive an index name from the current git repository.
+def derive_index_from_git(path: str | Path | None = None) -> str | None:
+    """Derive an index name from a git repository.
 
     Uses the main repo root (not the worktree root) so that all worktrees
     of the same repository derive the same index name.
 
+    Args:
+        path: Directory to resolve the git repo from. Defaults to the current
+            directory.
+
     Returns:
         Index name derived from git root directory, or None if not in a git repo.
     """
-    repo_root = get_main_repo_root()
+    repo_root = get_main_repo_root(path)
     if repo_root is None:
         return None
 

--- a/src/cocosearch/mcp/server.py
+++ b/src/cocosearch/mcp/server.py
@@ -641,6 +641,7 @@ async def api_extract_deps(request) -> JSONResponse:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
     index_name = body.get("index_name")
+    fresh = body.get("fresh", False)
     if not index_name:
         return JSONResponse({"error": "index_name is required"}, status_code=400)
 
@@ -659,7 +660,9 @@ async def api_extract_deps(request) -> JSONResponse:
     try:
         from cocosearch.deps.extractor import extract_dependencies
 
-        stats = await asyncio.to_thread(extract_dependencies, index_name, source_path)
+        stats = await asyncio.to_thread(
+            extract_dependencies, index_name, source_path, fresh=fresh
+        )
         edges = stats.get("edges_found", 0)
         return JSONResponse(
             {

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -93,6 +93,45 @@ class TestFindConfigFile:
 
         assert result is None
 
+    def test_start_dir_anchors_search_to_target(self, tmp_path, monkeypatch):
+        """start_dir finds config in the target directory, not cwd."""
+        # cwd has its own config that must be ignored
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        (cwd / "cocosearch.yaml").write_text("indexName: cwd")
+        monkeypatch.chdir(cwd)
+
+        # Target directory has a different config
+        target = tmp_path / "target"
+        target.mkdir()
+        target_config = target / "cocosearch.yaml"
+        target_config.write_text("indexName: target")
+
+        result = find_config_file(target)
+        assert result == target_config
+
+    def test_start_dir_falls_back_to_target_git_root(self, tmp_path, monkeypatch):
+        """With start_dir, git discovery is run against the target directory."""
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "target"
+        target.mkdir()
+        git_root = tmp_path / "repo"
+        git_root.mkdir()
+        git_config = git_root / "cocosearch.yaml"
+        git_config.write_text("indexName: repo")
+
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.stdout = str(git_root) + "\n"
+            mock_run.return_value = mock_result
+            result = find_config_file(target)
+
+        # git was invoked with -C pointing at the target directory
+        called_cmd = mock_run.call_args[0][0]
+        assert "-C" in called_cmd
+        assert str(target) in called_cmd
+        assert result == git_config
+
 
 class TestLoadConfig:
     """Test config loading and validation."""

--- a/tests/unit/deps/test_cli.py
+++ b/tests/unit/deps/test_cli.py
@@ -90,6 +90,45 @@ class TestDepsExtractCommand:
         call_args = mock_extract.call_args[0]
         assert os.path.isabs(call_args[1])
 
+    @patch("cocosearch.cli.extract_dependencies")
+    @patch("cocosearch.cli._resolve_index_name", return_value=("myindex", "config"))
+    @patch("cocosearch.cli.load_project_config")
+    @patch("cocosearch.cli.find_config_file", return_value="/fake/cocosearch.yaml")
+    def test_resolves_index_from_target_path_not_cwd(
+        self, mock_find, mock_load, mock_resolve, mock_extract
+    ):
+        """Regression: config + index name must be anchored to the target path.
+
+        Previously the index name was resolved from the caller's cwd, so
+        `deps extract /other/repo --fresh` from a project dir would wipe and
+        re-extract *this* project's index against the wrong files.
+        """
+        import os
+
+        mock_extract.return_value = {
+            "files_processed": 0,
+            "files_skipped": 0,
+            "edges_found": 0,
+            "errors": 0,
+        }
+
+        args = MagicMock()
+        args.name = None
+        args.path = "/some/other/repo"
+        args.fresh = True
+
+        from cocosearch.cli import deps_extract_command
+
+        result = deps_extract_command(args)
+
+        assert result == 0
+        expected_path = os.path.abspath("/some/other/repo")
+        # Config discovery is anchored to the target codebase, not cwd.
+        mock_find.assert_called_once_with(expected_path)
+        # Index-name resolution falls back to the target codebase.
+        assert mock_resolve.call_args.kwargs["fallback_path"] == expected_path
+        mock_extract.assert_called_once_with("myindex", expected_path, fresh=True)
+
 
 # ============================================================================
 # Tests: deps_show_command

--- a/tests/unit/management/test_git.py
+++ b/tests/unit/management/test_git.py
@@ -76,6 +76,15 @@ class TestDeriveIndexFromGit:
         result = derive_index_from_git()
         assert result is None
 
+    def test_passes_path_to_git(self, fp):
+        """A path argument is forwarded to git via -C (resolve from target)."""
+        fp.register(
+            ["git", "-C", "/other/repo", "rev-parse", "--git-common-dir"],
+            stdout="/other/repo/.git\n",
+        )
+        result = derive_index_from_git("/other/repo")
+        assert result == "repo"
+
     def test_uses_directory_name_not_full_path(self, fp):
         """Uses only the last directory component for index name."""
         fp.register(

--- a/tests/unit/mcp/test_api_smoke.py
+++ b/tests/unit/mcp/test_api_smoke.py
@@ -467,6 +467,47 @@ class TestApiExtractDepsSmoke:
         assert "42" in body["message"]
         assert body["stats"]["edges_found"] == 42
 
+    @pytest.mark.asyncio
+    async def test_default_extraction_is_incremental(self, client):
+        """Omitting fresh forwards fresh=False (incremental) to the extractor."""
+        metadata = {"canonical_path": "/projects/myproject"}
+        stats = {"edges_found": 42}
+
+        with patch("cocosearch.mcp.server.get_index_metadata", return_value=metadata):
+            with patch(
+                "cocosearch.deps.extractor.extract_dependencies",
+                return_value=stats,
+            ) as mock_extract:
+                response = await client.post(
+                    "/api/extract-deps", json={"index_name": "myindex"}
+                )
+
+        assert response.status_code == 200
+        mock_extract.assert_called_once_with(
+            "myindex", "/projects/myproject", fresh=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_extraction_with_fresh_flag(self, client):
+        """fresh=True is forwarded to extract_dependencies (full re-extraction)."""
+        metadata = {"canonical_path": "/projects/myproject"}
+        stats = {"edges_found": 42}
+
+        with patch("cocosearch.mcp.server.get_index_metadata", return_value=metadata):
+            with patch(
+                "cocosearch.deps.extractor.extract_dependencies",
+                return_value=stats,
+            ) as mock_extract:
+                response = await client.post(
+                    "/api/extract-deps",
+                    json={"index_name": "myindex", "fresh": True},
+                )
+
+        assert response.status_code == 200
+        mock_extract.assert_called_once_with(
+            "myindex", "/projects/myproject", fresh=True
+        )
+
 
 class TestApiGrammarsSmoke:
     """Tests for GET /api/grammars through the ASGI stack."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -99,6 +99,44 @@ class TestIndexCommand:
                     result = index_command(args)
         assert result == 0
 
+    def test_resolves_index_from_target_path_not_cwd(self, capsys, tmp_codebase):
+        """Regression: config + index name must be anchored to the target path.
+
+        Previously config discovery used the caller's cwd, so `index /other/repo`
+        run from a project dir would pick up *this* project's cocosearch.yaml and
+        index name instead of the target repo's. (deps_extract_command has the
+        equivalent regression test; this covers index_command for parity.)
+        """
+        import os
+
+        with (
+            patch("cocosearch.cli.run_index") as mock_run,
+            patch("cocosearch.cli.IndexingProgress"),
+            patch("cocosearch.cli.register_index_path"),
+            patch("cocosearch.cli.find_config_file", return_value=None) as mock_find,
+            patch(
+                "cocosearch.cli._resolve_index_name",
+                return_value=("myindex", "git"),
+            ) as mock_resolve,
+        ):
+            mock_run.return_value = MagicMock(stats={"files": {"num_insertions": 1}})
+            args = argparse.Namespace(
+                path=str(tmp_codebase),
+                name=None,
+                include=None,
+                exclude=None,
+                no_gitignore=False,
+                fresh=False,
+            )
+            result = index_command(args)
+
+        assert result == 0
+        expected_path = os.path.abspath(str(tmp_codebase))
+        # Config discovery is anchored to the target codebase, not cwd.
+        mock_find.assert_called_once_with(expected_path)
+        # Index-name resolution falls back to the target codebase.
+        assert mock_resolve.call_args.kwargs["fallback_path"] == expected_path
+
     def test_stores_branch_info(self, capsys, tmp_codebase):
         """index_command passes branch and commit_hash to register_index_path."""
         with (


### PR DESCRIPTION
Summary

  Two related dependency-extraction safety fixes, discovered while diagnosing why another repository index had thin
  dependency data (only workflow-YAML edges, no Python).

  1. CLI index-resolution data-loss bug 🐛

  cocosearch deps extract <path> resolved the index name from the caller's cwd, not the target path. All three
  resolution steps — config discovery (find_config_file), git derivation (derive_index_from_git), and the derived-name
  fallback — ignored the path argument.

  Impact: run from a project directory, deps extract /other/repo --fresh resolves to this project's index and wipes its
  edges while re-extracting against the wrong files. (index <path> had the same latent bug; fallback_path only masked
  it when no cwd config existed.)

  Fix:
  - find_config_file(start_dir=None) — anchor config + git-root discovery to a given directory (git-root lookup now
  uses git -C)
  - derive_index_from_git(path=None) — forward the path to get_main_repo_root
  - _resolve_index_name — pass fallback_path into the git step
  - deps_extract_command / index_command — anchor config + index-name resolution to the target codebase path

  Backward compatible (new params default to cwd behavior). The read-only deps show/tree/impact/stats commands are
  intentionally untouched — they take a relative file arg and are meant to run in-project.

  2. Dashboard "Fresh Extract Deps" ✨

  The dashboard "Extract Deps" button only ran incremental extraction, so files unchanged since a stale/broken index
  were never re-extracted (the button reported success but did nothing for them). Added a fresh path end to end:
  - /api/extract-deps now accepts a fresh flag, forwarded to extract_dependencies
  - A red "Fresh Extract Deps" button mirrors the existing Reindex / Fresh Index two-button pattern

  Testing

  - New unit tests: find_config_file start_dir anchoring (+ git-root variant), derive_index_from_git path forwarding,
  deps_extract_command regression (resolves from target path, not cwd), /api/extract-deps fresh-flag forwarding
  (default + explicit)
  - Full suite green (1257 passing across affected areas), ruff clean
  - E2E: re-ran the exact command that corrupted an index pre-fix (deps extract <other-repo> --fresh, no --name, from a
  different project dir) — now correctly targets the right index and leaves the cwd project's edges untouched