### PR TITLE
fix(dashboard): show index name in the warning banner header

### DIFF
--- a/src/cocosearch/dashboard/web/static/css/styles.css
+++ b/src/cocosearch/dashboard/web/static/css/styles.css
@@ -338,6 +338,22 @@ header {
     margin-bottom: 8px;
 }
 
+/* Index-name chip in the warning header — clarifies which index the warnings
+   belong to (e.g. a fallback index when the current project is unindexed).
+   White monospace on a translucent pill for legibility on the red banner. */
+.warning-index-chip {
+    display: inline-block;
+    font-family: var(--font-mono, monospace);
+    font-size: 14px;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.22);
+    color: white;
+    padding: 1px 8px;
+    border-radius: 6px;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
 .warning-banner ul {
     list-style: none;
     padding-left: 0;

--- a/src/cocosearch/dashboard/web/static/index.html
+++ b/src/cocosearch/dashboard/web/static/index.html
@@ -77,7 +77,7 @@
         </div>
 
         <div id="warningBanner" class="warning-banner">
-            <h3>Index Warnings</h3>
+            <h3><span id="warningIndexName" class="warning-index-chip" style="display: none;"></span>Index Warnings</h3>
             <ul id="warningList"></ul>
         </div>
 

--- a/src/cocosearch/dashboard/web/static/js/dashboard.js
+++ b/src/cocosearch/dashboard/web/static/js/dashboard.js
@@ -202,11 +202,23 @@ export function updateSummaryCards(stats) {
     }
 }
 
-export function updateWarnings(warnings) {
+export function updateWarnings(warnings, indexName) {
     const banner = document.getElementById('warningBanner');
     const list = document.getElementById('warningList');
+    const nameChip = document.getElementById('warningIndexName');
 
     if (warnings && warnings.length > 0) {
+        // Surface which index the warnings belong to — important when the
+        // current project is unindexed and a fallback index is shown.
+        if (nameChip) {
+            if (indexName) {
+                nameChip.textContent = indexName;
+                nameChip.style.display = '';
+            } else {
+                nameChip.textContent = '';
+                nameChip.style.display = 'none';
+            }
+        }
         list.innerHTML = warnings.map(w => `<li>${escapeHtml(w)}</li>`).join('');
         banner.classList.add('visible');
     } else {
@@ -471,7 +483,7 @@ export function updateDashboard(stats) {
     state.parseFailuresData = stats.parse_failures || [];
     state.grammarFailuresData = stats.grammar_failures || [];
     updateSummaryCards(stats);
-    updateWarnings(stats.warnings);
+    updateWarnings(stats.warnings, stats.name);
     // Populate language filter before charts — charts depend on CDN libs
     // and a failure there must not prevent the filter from updating
     populateLanguageFilter(stats.languages || []);

--- a/tests/unit/dashboard/test_html_structure.py
+++ b/tests/unit/dashboard/test_html_structure.py
@@ -292,3 +292,25 @@ def test_crt_effects_disabled_in_light_mode():
     assert ':root[data-theme="light"] body::after' in content, (
         "Missing rule to hide body::after vignette in light mode"
     )
+
+
+def test_warning_banner_has_index_name_chip(soup):
+    """The warning banner header must carry the index-name chip span so the
+    dashboard can show which index the warnings belong to."""
+    banner = soup.find(id="warningBanner")
+    assert banner is not None, "warningBanner element missing"
+    chip = banner.find(id="warningIndexName")
+    assert chip is not None, "warningIndexName chip span missing from warning banner"
+    assert "warning-index-chip" in chip.get("class", []), (
+        "warningIndexName span missing the warning-index-chip class"
+    )
+    # The literal 'Index Warnings' header text must remain alongside the chip
+    assert "Index Warnings" in banner.get_text()
+
+
+def test_warning_index_chip_styled():
+    """styles.css must define the .warning-index-chip rule (monospace pill)."""
+    content = (CSS_DIR / "styles.css").read_text()
+    assert ".warning-index-chip {" in content, (
+        "Missing .warning-index-chip rule in styles.css"
+    )


### PR DESCRIPTION
When the current project is unindexed, the dashboard falls back to the first available index and renders its staleness/drift warnings. Those warnings read as if they apply to the current project, which is misleading. Prefix the "Index Warnings" header with the index name the warnings actually belong to, rendered as a white monospace chip (legible on the red banner). The chip is hidden when no index name is available, so the header degrades to plain "Index Warnings".

- index.html: add #warningIndexName chip span inside the banner header
- dashboard.js: updateWarnings(warnings, indexName) sets/hides the chip; caller passes stats.name
- styles.css: .warning-index-chip (translucent pill, IBM Plex Mono)
- tests: assert the chip span + class exist in the banner and CSS