### PR TITLE
chore(renovate): hold mcp and ruff below the majors that break us

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold mcp below 2.0. The 2.0 SDK removed mcp.server.fastmcp (renamed to mcp.server.mcpserver, FastMCP to MCPServer), which src/cocosearch/mcp/server.py and mcp/project_detection.py import from. An unbounded range let uvx resolve 2.0.0 and the server died at import, surfacing only as '-32000: Connection closed'. Lift this together with the port to MCPServer.",
+      "matchPackageNames": [
+        "mcp"
+      ],
+      "allowedVersions": "<2.0.0"
+    },
+    {
+      "description": "Hold ruff below 0.16. The 0.16 release expanded its default rule selection, and with no [tool.ruff] section in this repo we run on defaults, so the new rules applied retroactively to the whole tree: 1087 findings, led by RUF059, SIM117 and BLE001. Lift this together with an explicit select list and the resulting fixes.",
+      "matchPackageNames": [
+        "ruff"
+      ],
+      "allowedVersions": "<0.16"
+    }
   ]
 }


### PR DESCRIPTION
## Why

The `mcp<2.0.0` and `ruff<0.16` caps landed in #93 as fixes. Renovate has already opened PRs to lift both:

- **#95** — `mcp[cli]>=1.26.0,<2.0.0` → `>=2.0.0,<2.1.0`
- **#94** — `ruff>=0.14.14,<0.16` → `>=0.16,<0.17`

Each one reintroduces exactly the failure its cap exists to prevent. A bounded range reads to Renovate as something to bump, so setting the cap isn't enough — it has to be *held*.

## What

`allowedVersions` rules for both packages, so Renovate stops proposing versions past the cap and closes the two open PRs on its next run.

Each rule states its lift condition in `description`, so whoever picks up the migration knows what has to be true first:

- **mcp** — lift together with the port to the `MCPServer` API
- **ruff** — lift together with an explicit `[tool.ruff]` `select` list and the resulting fixes

## Verification

- `renovate-config-validator renovate.json` → `INFO: Config validated successfully`
- JSON parses; both rules resolve to `(['mcp'], '<2.0.0')` and `(['ruff'], '<0.16')`

## Follow-up

Neither cap should be permanent. Both migrations are worth doing — this just stops them happening by accident, in a dependency bump, without the accompanying code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)