### PR TITLE
chore(ci): run checks for workflow and interpreter-version changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,13 @@ jobs:
               - 'tests/**'
               - 'pyproject.toml'
               - 'uv.lock'
+              # A change to the workflows or to the interpreter version can
+              # break lint and tests without touching a line of src/. Left out
+              # of this filter, such a PR skips every job and reports all
+              # checks green having run none of them.
+              - '.github/workflows/**'
+              - '.python-version'
+              - 'Dockerfile'
             versions:
               - 'pyproject.toml'
               - 'src/cocosearch/__init__.py'


### PR DESCRIPTION
## Problem

The `python` path filter (`ci.yaml:25-30`) covered only `src/**`, `tests/**`, `pyproject.toml` and `uv.lock`. Lint, Unit Tests and Skills Sync are all gated on it.

So a PR that changes only the workflows, `.python-version`, or the `Dockerfile` skips every job — and GitHub reports the PR as green, having run nothing.

This is not hypothetical. Of the Renovate PRs currently open, four show `skipping` rather than `pass`:

| PR | Change | Checks |
|---|---|---|
| #92 | setup-uv → v9 | all skipping |
| #88 | actions/checkout → v7 | all skipping |
| #89 | actions/cache → v6 | all skipping |
| #53 | python docker tag → 3.14 | all skipping |

Three of those modify CI itself and one changes the interpreter — the changes most likely to break the build are the ones the build never sees. You find out after merging to `main`.

## Change

Adds `.github/workflows/**`, `.python-version` and `Dockerfile` to the `python` filter.

## Verification

- `ci.yaml` parses; filter resolves to `['src/**', 'tests/**', 'pyproject.toml', 'uv.lock', '.github/workflows/**', '.python-version', 'Dockerfile']`
- **This PR is its own test case.** It touches `.github/workflows/**` and nothing else, so on `main` today it would skip everything. If the checks below actually ran, the fix works.

## Note

This makes the four PRs above run real checks once rebased, which may surface genuine failures that were previously invisible. That is the point, but it means they should be merged one at a time rather than batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)