### PR TITLE
fix(release): pin ruff so tagging can publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,11 +49,15 @@ jobs:
           enable-cache: true
           python-version: ${{ env.PYTHON_VERSION }}
 
+      # Pinned to match ci.yaml and the dev-group cap in pyproject.toml.
+      # Unversioned `uvx ruff` resolves to the newest release, and 0.16.0
+      # expanded the default rule set — here that would fail `test`, which
+      # publish-testpypi depends on, so a release would build nothing.
       - name: Ruff check
-        run: uvx ruff check src/ tests/
+        run: uvx ruff@0.15.0 check src/ tests/
 
       - name: Ruff format check
-        run: uvx ruff format --check src/ tests/
+        run: uvx ruff@0.15.0 format --check src/ tests/
 
       - name: Restore cached virtual environment
         uses: actions/cache@v5


### PR DESCRIPTION
## Problem

#93 pinned `uvx ruff` in `ci.yaml` but missed the identical pair in `release.yaml` — my oversight. The release path still runs unversioned:

```yaml
- name: Ruff check
  run: uvx ruff check src/ tests/
- name: Ruff format check
  run: uvx ruff format --check src/ tests/
```

With ruff 0.16.0 released, that is 1087 findings in the `test` job. And the job graph makes `test` load-bearing for publishing:

```
validate ──┬─> test ──┐
           └─> build ─┴─> publish-testpypi -> publish-pypi -> update-version
                                                           └─> github-release
```

So tagging `v0.1.49` today fails at `test` and **publishes nothing** — CI would be green on `main` while the release silently cannot ship.

## Change

Pins both steps to `ruff@0.15.0`, matching `ci.yaml` and the `<0.16` dev-group cap. All three now agree on one version.

## Verification

- `release.yaml` parses; `test` job steps resolve to `uvx ruff@0.15.0 check`, `uvx ruff@0.15.0 format --check`, `uv sync --frozen`, `uv run pytest`
- Both pinned commands pass locally: `All checks passed!` / `248 files already formatted`

## Why this matters now

This blocks **0.1.49**, which is what finally puts the `mcp<2.0.0` cap on PyPI. Until that release ships, every `uvx --from cocosearch` install still resolves `mcp` 2.0.0 and the MCP server dies at import — the cap on `main` does nothing for users until it is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)